### PR TITLE
Remove required args from publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - main
-
   workflow_dispatch:
-    inputs:
-      version:
-        required: true
-        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
The publish job initially required a `version` argument (or it was going to require one).  It doesn't now, so I've removed that.