### PR TITLE
Limit width on smaller screens

### DIFF
--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -26,6 +26,7 @@ title: GeoParquet
     body {
       margin: 1em auto;
       font-family: "Lucida Grande", "Lucida Sans Unicode", Arial, Verdana, sans-serif;
+      width: 90%;
       max-width: 950px;
     }
 


### PR DESCRIPTION
This makes it so the content doesn't bump into the edges on smaller screens.