### PR TITLE
Use token in GitHub API requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,6 @@ jobs:
         run: npm test
 
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build

--- a/src/_data/releases.js
+++ b/src/_data/releases.js
@@ -25,7 +25,9 @@ const altPaths = {
  */
 async function getReleaseTags() {
   process.removeAllListeners('warning');
-  const client = new OctokitClient();
+  const client = new OctokitClient({
+    auth: process.env.GITHUB_TOKEN,
+  });
 
   const tags = await client.paginate(
     client.rest.repos.listReleases,


### PR DESCRIPTION
The test job is [periodically failing](https://github.com/geoparquet/geoparquet.github.io/actions/runs/3707783849/jobs/6284607366) after retries due to rate limits.  This adds change should increase the rate limits by authenticating first.