### PR TITLE
additional command to get qgis working with geoparquet

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -136,7 +136,7 @@ const latest = (await releases)[0];
         href="https://geopandas.org/en/stable/docs/reference/api/geopandas.read_parquet.html">writing</a> GeoParquet.
       </li>
       <li>
-        <a href="https://qgis.org">QGIS</a> Windows and Linux ship with GeoParquet support, and Mac can work installing with <a href="https://docs.conda.io/en/latest/">conda</a> (from the terminal with conda activated run 'conda install qgis libgdal-arrow-parquet', and then just type 'qgis' in the terminal). 
+        <a href="https://qgis.org">QGIS</a> Windows and Linux ship with GeoParquet support, and Mac can work installing with <a href="https://docs.conda.io/en/latest/">conda</a> (from the terminal with conda activated run 'conda config --add channels conda-forge', 'conda install qgis libgdal-arrow-parquet', and then just type 'qgis' in the terminal).
       </li>
       <li>
         <a href="https://www.scribblemaps.com/">Scribble Maps</a> is a full-featured web app that supports both import & export of GeoParquet.


### PR DESCRIPTION
Adding a command to get QGIS working with geoparquet via conda. As a non-conda Mac user, thought I would help others out. 