### PR TITLE
Handle build metadata in release tags

### DIFF
--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -12,7 +12,7 @@ const older = allReleases.slice(1);
   <h2>Latest Release</h2>
   <ul>
     <li>
-      <a href={"./" + latest.tag + "/"}>{latest.tag}</a> (<a href={"./" + latest.tag + "/schema.json"}>schema</a>)
+      <a href={"./v" + latest.version + "/"}>v{latest.version}</a> (<a href={"./v" + latest.version + "/schema.json"}>schema</a>)
     </li>
   </ul>
 
@@ -20,7 +20,7 @@ const older = allReleases.slice(1);
   <ul>
   {older.map(release =>
     <li>
-      <a href={"./" + release.tag + "/"}>{release.tag}</a> (<a href={"./" + release.tag + "/schema.json"}>schema</a>)
+      <a href={"./v" + release.version + "/"}>v{release.version}</a> (<a href={"./v" + release.version + "/schema.json"}>schema</a>)
     </li>
   )}
   </ul>

--- a/src/pages/releases/v[version].astro
+++ b/src/pages/releases/v[version].astro
@@ -3,16 +3,16 @@ import Layout from '../../layouts/Layout.astro';
 import {releases} from '../../releases.js';
 import {marked} from 'marked';
 
-const {tag} = Astro.params;
-const release = (await releases).find(r => r.tag === tag);
+const {version} = Astro.params;
+const release = (await releases).find(r => r.version === version);
 if (!release) {
-  throw new Error(`Unrecognized tag: ${tag}`);
+  throw new Error(`Unrecognized version: ${version}`);
 }
 const content = marked.parse(release.spec);
 
 export async function getStaticPaths() {
   return (await releases).map(r => (
-    {params: {tag: r.tag}}
+    {params: {version: r.version}}
   ));
 }
 ---

--- a/src/pages/releases/v[version]/schema.json.js
+++ b/src/pages/releases/v[version]/schema.json.js
@@ -1,12 +1,12 @@
 import {releases} from '../../../releases.js';
 
 export async function getStaticPaths() {
-  return (await releases).map(r => ({params: {tag: r.tag}}));
+  return (await releases).map(r => ({params: {version: r.version}}));
 }
 
 export async function GET({params}) {
-  const tag = params.tag;
-  const release = (await releases).find(r => r.tag === tag);
+  const version = params.version;
+  const release = (await releases).find(r => r.version === version);
   if (!release) {
     return new Response('Not found', {status: 404});
   }


### PR DESCRIPTION
This makes it so we can have multiple release tags with ascending build metadata (e.g. `v1.1.0+p1`, `v1.1.0+p2`).  In collecting the release information, only the most recent version will be used when there are multiple tags referencing the same version with different build metadata.

Here are some example valid tags and the corresponding version (sorted from least to most recent):

| Tag | Version |
|-----|---------|
| `v1.0.0-beta.1`  | `1.0.0-beta.1` |
| `v1.0.0` | `1.0.0` |
| `v1.1.0` | `1.1.0` |
| `v1.1.0+p1` | `1.1.0` |
| `v1.1.0+p2` | `1.1.0` |
| `v1.1.1` | `1.1.1` |
