### PR TITLE
Add emotional.byteroad.net to the list of Data Providers & Sample Data

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -198,6 +198,9 @@ const latest = (await releases)[0];
           has over 800 million building footprints across Africa and SE Asia. And the <a href="https://beta.source.coop/cholmes/eurocrops">Eurocrops cloud-native distribution</a>
           provides over 20 million harmonized field boundaries across 16 different European countries.
       </li>
+      <li>
+        <a href="https://emotional.byteroad.net/catalogue">emotional.byteroad.net</a> provides most of its +100 datasets in GeoParquet. The GeoParquet files all linked through the metadata records.
+      </li>
     </ul>
   </section>
   


### PR DESCRIPTION
The eMOTIONAL Cities SDI publishes more than 100 datasets as GeoParquet. More information about this SDI and the publication of GeoParquet files can be found on [this](https://doublebyteblog.wordpress.com/2024/08/02/navigating-geoparquet-lessons-learned-from-the-emotional-cities-project/) blog post.