### PR TITLE
Add geoparquet.js

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,6 +170,7 @@ const latest = (await releases)[0];
       <li><a href="https://github.com/Toblerity/Fiona">Fiona</a> (Python - as of version 1.9.4. Note the GeoParquet driver will only be available if your system's GDAL library links libarrow; fiona wheels on PyPI do not include libarrow as it is rather large.)</li>
       <li><a href="https://github.com/bertt/geoparquet">.NET 6 library</a> (.NET)</li>
       <li><a href="https://gist.github.com/jpswinski/13074fc773f92a529f98b274e5ad5283">C++ example code</a> - see <a href="https://github.com/opengeospatial/geoparquet/discussions/164">this discussion topic</a> for more info.</li>
+      <li><a href="https://github.com/hyparam/geoparquet">GeoParquet.js</a> (JavaScript)</li>
     </ul>
   </section>
   


### PR DESCRIPTION
Add link to [hyparam/geoparquet](https://github.com/hyparam/geoparquet) which is a new library for converting geoparquet into geojson. It's written in 100% javascript, and is only 9.2kb compressed _including_ parquet parsing.
