### PR TITLE
Add GeoPQ Workbench to the tools list

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -165,6 +165,7 @@ const latest = (await releases)[0];
       <li>Google's <a href="https://cloud.google.com/bigquery?hl=en">Big Query</a> data warehouse supports <a href="https://cloud.google.com/bigquery/docs/geospatial-data#loading_geoparquet_files">loading</a> and writing GeoParquet.</li>
       <li><a href="https://atlas.co/">Atlas</a> is a browser-based GIS platform with collaboration capabilities that provides visualization and analysis of a variety of formats, including GeoParquet.</li>
       <li><a href="https://kepler-preview.foursquare.com/">Kepler GL 3.1</a> is a open source geospatial analysis tool for large-scale data sets, and it can load and display GeoParquet (<a href="https://github.com/keplergl/kepler.gl/releases/tag/v3.1.0">source code</a>).</li>
+      <li><a href="https://www.geomermaids.com/geopq-workbench">GeoPQ Workbench</a> is a native desktop app (macOS, Windows, Linux) that opens, inspects and queries GeoParquet with no server and no GDAL. It reads 1.0, 1.1 (WKB and GeoArrow) and 2.0 native geometry types, from local files or over https:// and s3:// range requests, grades a file against the format's performance levers and can rewrite it into a spatially ordered one with a bbox covering column, and includes a SQL console with spatial functions (<a href="https://github.com/gsueur/geopq-workbench">source code</a>).</li>
     </ul>
 
     <h2>Libraries</h2>


### PR DESCRIPTION
Adds [GeoPQ Workbench](https://www.geomermaids.com/geopq-workbench) to the Tools list.

It is a free and open source (MIT/Apache-2.0) native desktop app for macOS, Windows and Linux, written in Rust with no GDAL dependency and no server. Relevant to this list:

- Reads GeoParquet 1.0, 1.1 (WKB and GeoArrow) and 2.0 native `GEOMETRY`/`GEOGRAPHY`, plus untagged parquet with a guessable geometry column.
- Opens files in place over `https://` and `s3://` range requests, reading only the row groups under the viewport; hive-partitioned prefixes open as one layer.
- Grades a file against the levers that affect read performance (spatial ordering, bbox covering column, row group sizing, page index, compression, metadata) and explains each miss, then can rewrite it into a best-practice file.
- SQL console over loaded layers with spatial functions and predicate pushdown into the parquet reads.

Source: https://github.com/gsueur/geopq-workbench

`npm run build` and `npm run lint` both pass on the branch.