### PR TITLE
Add anchor ids to spec headings so sections can be linked directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/semver": "^7.3.13",
         "astro": "^5.15.9",
         "marked": "^9.0.0",
+        "marked-gfm-heading-id": "^3.2.0",
         "semver": "^7.3.8",
         "typescript": "^5.2.2"
       },
@@ -5575,6 +5576,18 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/marked-gfm-heading-id": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-3.2.0.tgz",
+      "integrity": "sha512-Xfxpr5lXLDLY10XqzSCA9l2dDaiabQUgtYM9hw8yunyVsB/xYBRpiic6BOiY/EAJw1ik1eWr1ET1HKOAPZBhXg==",
+      "license": "MIT",
+      "dependencies": {
+        "github-slugger": "^2.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=4 <13"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/semver": "^7.3.13",
     "astro": "^5.15.9",
     "marked": "^9.0.0",
+    "marked-gfm-heading-id": "^3.2.0",
     "semver": "^7.3.8",
     "typescript": "^5.2.2"
   },

--- a/src/pages/releases/v[version].astro
+++ b/src/pages/releases/v[version].astro
@@ -1,13 +1,18 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import {releases} from '../../releases.js';
-import {marked} from 'marked';
+import {Marked} from 'marked';
+import {gfmHeadingId} from 'marked-gfm-heading-id';
 
 const {version} = Astro.params;
 const release = (await releases).find(r => r.version === version);
 if (!release) {
   throw new Error(`Unrecognized version: ${version}`);
 }
+
+// Adds an `id` attribute to each heading (GitHub-style slug), so that
+// sections of the spec can be linked to directly, e.g. `#geometry_types`.
+const marked = new Marked().use(gfmHeadingId());
 const content = marked.parse(release.spec);
 
 export async function getStaticPaths() {


### PR DESCRIPTION
Release spec pages are rendered from Markdown with `marked`, which by
default emits plain `<h1>`-`<h4>` tags without `id` attributes. That
makes it impossible to link to a specific section of the spec, e.g.
`/releases/v2.0.0/#geometry_types`.

This uses the `marked-gfm-heading-id` extension to add GitHub-style
slug ids to every heading, matching the anchors GitHub already
generates for the same Markdown file when viewed in a repo.

Since release pages are rendered from the tagged spec at build time,
this takes effect for *all* releases (past and future) the next time
the site is rebuilt — it doesn't change any spec content, just how
existing headings are rendered.

Verified locally: `npm run build`, `npm run lint`, `npm run typecheck`
all pass, and `dist/releases/v2.0.0-rc.1/index.html` now contains
`<h4 id="geometry_types">geometry_types</h4>` etc.

Fixes opengeospatial/geoparquet#249

---
🤖 Generated by [Claude Code](https://claude.com/claude-code) on behalf of @brawer.